### PR TITLE
(FIX) Data Analysis (Q.73) blank line

### DIFF
--- a/_data/files/data_analysis.yml
+++ b/_data/files/data_analysis.yml
@@ -1,6 +1,6 @@
 - h2: Data Analysis
        
-- question: How to find outliers in a dataset?
+  question: How to find outliers in a dataset?
   answer: >
     Here are some tools and techniques you can use to find outliers: 
     <ul>


### PR DESCRIPTION
Markdown typo causing an extra blank line:
<img width="559" height="281" alt="image" src="https://github.com/user-attachments/assets/ba68a475-4745-455c-9585-915275ebf22a" />
